### PR TITLE
[ETF-565] computeScore method + ts support

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  semi: true,
+  trailingComma: 'all',
+  singleQuote: true,
+  printWidth: 120,
+  tabWidth: 2,
+  overrides: [
+    {
+      files: '*.json',
+      options: {
+        printWidth: 80,
+      },
+    },
+  ],
+};

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ onSearch: (searchQuery) => {
     email: 'brad@mixmax.com'
   };
 
-  return peopleFrecency.compteScore({
+  return peopleFrecency.computeScore({
     searchQuery,
     item,
   });

--- a/README.md
+++ b/README.md
@@ -5,20 +5,23 @@ Plugin to add frecency to search results. Original blog post on Frecency by Slac
 ## Using The Module
 
 Install the npm module:
+
 ```sh
 npm install frecency
 ```
 
 Import Frecency into your code and create an instance of Frecency.
+
 ```js
 import Frecency from 'frecency';
 
 export const peopleFrecency = new Frecency({
-  key: 'people'   // Frecency data will be saved in localStorage with the key: 'frecency_people'.
+  key: 'people', // Frecency data will be saved in localStorage with the key: 'frecency_people'.
 });
 ```
 
 When you select a search result in your code, update frecency:
+
 ```js
 onSelect: (searchQuery, selectedResult) => {
   ...
@@ -31,6 +34,7 @@ onSelect: (searchQuery, selectedResult) => {
 ```
 
 Before you display search results to your users, sort the results using frecency:
+
 ```js
 onSearch: (searchQuery) => {
   ...
@@ -60,47 +64,69 @@ You can output results with scores by assigning `keepScores` parameter to `true`
 Keep the frecency score allow you to do extra operations like usage analytics, debugging
 and/or mix with other algorithms.
 
+### Compute score on individual item
+
+You can use the `.computeScore` method to calculate individual score on a given item
+
+```js
+onSearch: (searchQuery) => {
+  ...
+  // a single item we need to compute the score
+  const item = {
+    _id: '57b409d4feea972a68ba1101',
+    name: 'Brad Vogel',
+    email: 'brad@mixmax.com'
+  };
+
+  return peopleFrecency.compteScore({
+    searchQuery,
+    item,
+  });
+}
+```
 
 ## Configuring Frecency
+
 Frecency will sort on the `_id` attribute by default. You can change this by setting an
 `idAttribute` in the constructor:
+
 ```js
 const frecency = new Frecency({
   key: 'people',
-  idAttribute: 'id'
+  idAttribute: 'id',
 });
 
 // OR
 
 const frecency = new Frecency({
   key: 'people',
-  idAttribute: 'email'
+  idAttribute: 'email',
 });
 
 // Then when saving frecency, make sure to save the correct attribute as the selectedId.
 frecency.save({
   searchQuery,
-  selectedId: selectedResult.email
+  selectedId: selectedResult.email,
 });
 
 // `idAttribute` also accepts a function if your search results contain a
 // mix of different types.
 const frecency = new Frecency({
   key: 'people',
-  idAttribute: (result) => result.id || result.email
+  idAttribute: (result) => result.id || result.email,
 });
 
 // Depending on the result, save the appropriate ID in frecency.
 frecency.save({
   searchQuery,
-  selectedId: selectedResult.id
+  selectedId: selectedResult.id,
 });
 
 // OR
 
 frecency.save({
   searchQuery,
-  selectedId: selectedResult.email
+  selectedId: selectedResult.email,
 });
 ```
 
@@ -109,10 +135,11 @@ More timestamps means more granular frecency scores, but frecency data will take
 space in localStorage.
 
 You can modify the number of timestamps saved with an option in the constructor.
+
 ```js
 new Frecency({
   key: 'people',
-  timeStampsLimit: 20   // Limit is 10 by default.
+  timeStampsLimit: 20, // Limit is 10 by default.
 });
 ```
 
@@ -120,22 +147,24 @@ Frecency stores a maximum number of IDs in localStorage. More IDs means more res
 can be sorted with frecency, but frecency data takes up more space in localStorage.
 
 To change the maximum number of different IDs stored in frecency:
+
 ```js
 new Frecency({
   key: 'people',
-  recentSelectionsLimit: 200   // Limit is 100 by default.
+  recentSelectionsLimit: 200, // Limit is 100 by default.
 });
 ```
 
 By default, frecency uses browser localStorage as storage provider in the browser environment.
 You can pass your own storage provider that implements the API Web Storage interface.
 For Node.js environment you can use a storage provider like [node-localstorage](https://github.com/lmaccherone/node-localstorage)
+
 ```js
 const storageProviderFrecencyFilePath = path.join(app.getPath('userData'), 'frecency');
 const storageProvider = new LocalStorage(storageProviderFrecencyFilePath);
 new Frecency({
   key: 'people',
-  storageProvider
+  storageProvider,
 });
 ```
 

--- a/flow-typed/npm/jest_v22.x.x.js
+++ b/flow-typed/npm/jest_v22.x.x.js
@@ -17,7 +17,7 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
      * An array that contains all the object instances that have been
      * instantiated from this mock function.
      */
-    instances: Array<TReturn>
+    instances: Array<TReturn>,
   },
   /**
    * Resets all information stored in the mockFn.mock.calls and
@@ -44,17 +44,13 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
    * that come from itself -- the only difference is that the implementation
    * will also be executed when the mock is called.
    */
-  mockImplementation(
-    fn: (...args: TArguments) => TReturn
-  ): JestMockFn<TArguments, TReturn>,
+  mockImplementation(fn: (...args: TArguments) => TReturn): JestMockFn<TArguments, TReturn>,
   /**
    * Accepts a function that will be used as an implementation of the mock for
    * one call to the mocked function. Can be chained so that multiple function
    * calls produce different results.
    */
-  mockImplementationOnce(
-    fn: (...args: TArguments) => TReturn
-  ): JestMockFn<TArguments, TReturn>,
+  mockImplementationOnce(fn: (...args: TArguments) => TReturn): JestMockFn<TArguments, TReturn>,
   /**
    * Accepts a string to use in test result output in place of "jest.fn()" to
    * indicate which mock function is being referenced.
@@ -71,14 +67,14 @@ type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
   /**
    * Sugar for only returning a value once inside your mock
    */
-  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>
+  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>,
 };
 
 type JestAsymmetricEqualityType = {
   /**
    * A custom Jasmine equality tester
    */
-  asymmetricMatch(value: mixed): boolean
+  asymmetricMatch(value: mixed): boolean,
 };
 
 type JestCallsType = {
@@ -88,19 +84,19 @@ type JestCallsType = {
   count(): number,
   first(): mixed,
   mostRecent(): mixed,
-  reset(): void
+  reset(): void,
 };
 
 type JestClockType = {
   install(): void,
   mockDate(date: Date): void,
   tick(milliseconds?: number): void,
-  uninstall(): void
+  uninstall(): void,
 };
 
 type JestMatcherResult = {
   message?: string | (() => string),
-  pass: boolean
+  pass: boolean,
 };
 
 type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
@@ -115,7 +111,7 @@ type JestPromiseType = {
    * Use resolves to unwrap the value of a fulfilled promise so any other
    * matcher can be chained. If the promise is rejected the assertion fails.
    */
-  resolves: JestExpectType
+  resolves: JestExpectType,
 };
 
 /**
@@ -146,7 +142,7 @@ type EnzymeMatchersType = {
   toIncludeText(text: string): void,
   toHaveValue(value: any): void,
   toMatchElement(element: React$Element<any>): void,
-  toMatchSelector(selector: string): void
+  toMatchSelector(selector: string): void,
 };
 
 type JestExpectType = {
@@ -290,7 +286,7 @@ type JestExpectType = {
    * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
    * matching the most recent snapshot when it is called.
    */
-  toThrowErrorMatchingSnapshot(): void
+  toThrowErrorMatchingSnapshot(): void,
 };
 
 type JestObjectType = {
@@ -346,7 +342,7 @@ type JestObjectType = {
    * implementation.
    */
   fn<TArguments: $ReadOnlyArray<*>, TReturn>(
-    implementation?: (...args: TArguments) => TReturn
+    implementation?: (...args: TArguments) => TReturn,
   ): JestMockFn<TArguments, TReturn>,
   /**
    * Determines if the given function is a mocked function.
@@ -366,11 +362,7 @@ type JestObjectType = {
    * The third argument can be used to create virtual mocks -- mocks of modules
    * that don't exist anywhere in the system.
    */
-  mock(
-    moduleName: string,
-    moduleFactory?: any,
-    options?: Object
-  ): JestObjectType,
+  mock(moduleName: string, moduleFactory?: any, options?: Object): JestObjectType,
   /**
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
@@ -449,33 +441,21 @@ type JestObjectType = {
    * Set the default timeout interval for tests and before/after hooks in milliseconds.
    * Note: The default timeout interval is 5 seconds if this method is not called.
    */
-  setTimeout(timeout: number): JestObjectType
+  setTimeout(timeout: number): JestObjectType,
 };
 
 type JestSpyType = {
-  calls: JestCallsType
+  calls: JestCallsType,
 };
 
 /** Runs this function after every test inside this context */
-declare function afterEach(
-  fn: (done: () => void) => ?Promise<mixed>,
-  timeout?: number
-): void;
+declare function afterEach(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
 /** Runs this function before every test inside this context */
-declare function beforeEach(
-  fn: (done: () => void) => ?Promise<mixed>,
-  timeout?: number
-): void;
+declare function beforeEach(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
 /** Runs this function after all tests have finished inside this context */
-declare function afterAll(
-  fn: (done: () => void) => ?Promise<mixed>,
-  timeout?: number
-): void;
+declare function afterAll(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
 /** Runs this function before any tests have started inside this context */
-declare function beforeAll(
-  fn: (done: () => void) => ?Promise<mixed>,
-  timeout?: number
-): void;
+declare function beforeAll(fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
 
 /** A context for grouping tests together */
 declare var describe: {
@@ -492,7 +472,7 @@ declare var describe: {
   /**
    * Skip running this describe block
    */
-  skip(name: JestTestName, fn: () => void): void
+  skip(name: JestTestName, fn: () => void): void,
 };
 
 /** An individual test unit */
@@ -504,11 +484,7 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  (
-    name: JestTestName,
-    fn?: (done: () => void) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
+  (name: JestTestName, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
   /**
    * Only run this test
    *
@@ -516,11 +492,7 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  only(
-    name: JestTestName,
-    fn?: (done: () => void) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
+  only(name: JestTestName, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
   /**
    * Skip running this test
    *
@@ -528,11 +500,7 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  skip(
-    name: JestTestName,
-    fn?: (done: () => void) => ?Promise<mixed>,
-    timeout?: number
-  ): void,
+  skip(name: JestTestName, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
   /**
    * Run the test concurrently
    *
@@ -540,17 +508,9 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  concurrent(
-    name: JestTestName,
-    fn?: (done: () => void) => ?Promise<mixed>,
-    timeout?: number
-  ): void
+  concurrent(name: JestTestName, fn?: (done: () => void) => ?Promise<mixed>, timeout?: number): void,
 };
-declare function fit(
-  name: JestTestName,
-  fn: (done: () => void) => ?Promise<mixed>,
-  timeout?: number
-): void;
+declare function fit(name: JestTestName, fn: (done: () => void) => ?Promise<mixed>, timeout?: number): void;
 /** An individual test unit */
 declare var test: typeof it;
 /** A disabled group of tests */
@@ -578,7 +538,7 @@ declare var expect: {
   objectContaining(value: Object): Object,
   /** Matches any received string that contains the exact expected string. */
   stringContaining(value: string): string,
-  stringMatching(value: string | RegExp): string
+  stringMatching(value: string | RegExp): string,
 };
 
 // TODO handle return type
@@ -599,10 +559,7 @@ declare var jasmine: {
   arrayContaining(value: Array<mixed>): Array<mixed>,
   clock(): JestClockType,
   createSpy(name: string): JestSpyType,
-  createSpyObj(
-    baseName: string,
-    methodNames: Array<string>
-  ): { [methodName: string]: JestSpyType },
+  createSpyObj(baseName: string, methodNames: Array<string>): { [methodName: string]: JestSpyType },
   objectContaining(value: Object): Object,
-  stringMatching(value: string): string
+  stringMatching(value: string): string,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5357,6 +5357,12 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1272,6 +1272,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -2471,6 +2481,13 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
@@ -2591,552 +2608,10 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "^2.1.0"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
-      }
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -5434,9 +4909,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
       "dev": true,
       "optional": true
     },
@@ -6532,6 +6007,17 @@
         "watch": "~0.18.0"
       },
       "dependencies": {
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -7193,6 +6679,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
+      "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "ci": "npm run lint && npm run build",
     "lint": "eslint .",
+    "prettier": "prettier '**/*.{js,jsx,ts,tsx}' --write",
     "lint:flow": "flow",
     "tsc": "tsc --noEmit -p .",
     "lint:all": "yarn run lint && yarn run lint:flow && yarn run tsc",
@@ -46,6 +47,7 @@
     "flow-bin": "^0.75.0",
     "fsevents": "^2.1.3",
     "jest": "^22.4.3",
+    "prettier": "^2.0.5",
     "rollup": "^0.57.1",
     "rollup-plugin-babel": "^2.6.1",
     "rollup-plugin-replace": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,14 +10,19 @@
     "dist",
     "src"
   ],
+  "types": "types/index.d.ts",
   "scripts": {
     "ci": "npm run lint && npm run build",
-    "lint": "eslint . && flow",
+    "lint": "eslint .",
+    "lint:flow": "flow",
+    "tsc": "tsc --noEmit -p .",
+    "lint:all": "yarn run lint && yarn run lint:flow && yarn run tsc",
     "prebuild": "rm -rf dist/",
     "build": "[ \"$WATCH\" == 'true' ] && rollup -cw || rollup -c",
     "test": "npm run build && jest",
+    "test:all": "npm run lint:all && npm run test",
     "watch": "WATCH=true yarn build",
-    "prepublish": "npm run lint && npm run build && npm test"
+    "prepublishOnly": "npm run test:all && npm run build"
   },
   "repository": {
     "type": "git",
@@ -39,9 +44,11 @@
     "eslint-config-mixmax": "^1.0.0",
     "eslint-plugin-flowtype": "^2.46.1",
     "flow-bin": "^0.75.0",
+    "fsevents": "^2.1.3",
     "jest": "^22.4.3",
     "rollup": "^0.57.1",
     "rollup-plugin-babel": "^2.6.1",
-    "rollup-plugin-replace": "^2.0.0"
+    "rollup-plugin-replace": "^2.0.0",
+    "typescript": "^3.9.6"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,19 +3,14 @@ import replace from 'rollup-plugin-replace';
 
 const pkg = require('./package.json');
 
-const presets = [
-  ['env', { modules: false }],
-  'flow'
-];
+const presets = [['env', { modules: false }], 'flow'];
 
 const commonPlugins = [
   babel({
     babelrc: false,
     presets,
-    plugins: [
-      'external-helpers'
-    ],
-    exclude: [ 'node_modules/**' ]
+    plugins: ['external-helpers'],
+    exclude: ['node_modules/**'],
   }),
 ];
 
@@ -30,7 +25,7 @@ export default [
       {
         format: 'es',
         file: pkg.browser['./index.js'],
-      }
+      },
     ],
     plugins: commonPlugins.concat([
       replace({
@@ -44,7 +39,7 @@ export default [
       {
         format: 'cjs',
         file: pkg.main,
-      }
+      },
     ],
     plugins: commonPlugins.concat([
       replace({
@@ -52,4 +47,4 @@ export default [
       }),
     ]),
   },
-]
+];

--- a/spec/mocks.js
+++ b/spec/mocks.js
@@ -10,7 +10,7 @@ export class LocalStorageMock {
 
   getItem(key: string) {
     const value = this.data[key];
-    return (!value && typeof value !== 'string') ? null : value;
+    return !value && typeof value !== 'string' ? null : value;
   }
 
   setItem(key: string, value: string) {
@@ -24,7 +24,7 @@ export class LocalStorageMock {
   key(n: number) {
     const key = Object.keys(this.data)[n];
     const value = this.data[key];
-    return (!value && typeof value !== 'string') ? null : value;
+    return !value && typeof value !== 'string' ? null : value;
   }
 
   clear() {

--- a/spec/save.test.js
+++ b/spec/save.test.js
@@ -13,10 +13,12 @@ describe('frecency', () => {
       global.localStorage = undefined;
       const frecency = new Frecency({ key: 'templates' });
 
-      expect(frecency.save({
-        searchQuery: 'search',
-        selectedId: 'test'
-      })).toBeUndefined();
+      expect(
+        frecency.save({
+          searchQuery: 'search',
+          selectedId: 'test',
+        }),
+      ).toBeUndefined();
     });
 
     it('stores multiple queries.', () => {
@@ -25,42 +27,46 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => 1524085045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       global.Date.now = jest.fn(() => 1524270045510);
       frecency.save({
         searchQuery: 'simon xi',
-        selectedId: 'simon xiong'
+        selectedId: 'simon xiong',
       });
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));
       expect(data).toEqual({
         queries: {
-          brad: [{
-            id: 'brad vogel',
-            timesSelected: 1,
-            selectedAt: [1524085045510]
-          }],
-          'simon xi': [{
-            id: 'simon xiong',
-            timesSelected: 1,
-            selectedAt: [1524270045510]
-          }],
+          brad: [
+            {
+              id: 'brad vogel',
+              timesSelected: 1,
+              selectedAt: [1524085045510],
+            },
+          ],
+          'simon xi': [
+            {
+              id: 'simon xiong',
+              timesSelected: 1,
+              selectedAt: [1524270045510],
+            },
+          ],
         },
         selections: {
           'brad vogel': {
             timesSelected: 1,
             selectedAt: [1524085045510],
-            queries: { brad: true }
+            queries: { brad: true },
           },
           'simon xiong': {
             timesSelected: 1,
             selectedAt: [1524270045510],
-            queries: { 'simon xi': true }
-          }
+            queries: { 'simon xi': true },
+          },
         },
-        recentSelections: ['simon xiong', 'brad vogel', ]
+        recentSelections: ['simon xiong', 'brad vogel'],
       });
     });
 
@@ -70,42 +76,45 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => 1524085045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       global.Date.now = jest.fn(() => 1524270045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));
       expect(data).toEqual({
         queries: {
-          brad: [{
-            id: 'brad vogel',
-            timesSelected: 1,
-            selectedAt: [1524085045510]
-          }, {
-            id: 'brad neuberg',
-            timesSelected: 1,
-            selectedAt: [1524270045510]
-          }],
+          brad: [
+            {
+              id: 'brad vogel',
+              timesSelected: 1,
+              selectedAt: [1524085045510],
+            },
+            {
+              id: 'brad neuberg',
+              timesSelected: 1,
+              selectedAt: [1524270045510],
+            },
+          ],
         },
         selections: {
           'brad vogel': {
             timesSelected: 1,
             selectedAt: [1524085045510],
-            queries: { brad: true }
+            queries: { brad: true },
           },
           'brad neuberg': {
             timesSelected: 1,
             selectedAt: [1524270045510],
-            queries: { brad: true }
+            queries: { brad: true },
           },
         },
 
-        recentSelections: ['brad neuberg', 'brad vogel']
+        recentSelections: ['brad neuberg', 'brad vogel'],
       });
     });
 
@@ -115,38 +124,40 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => 1524085045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       global.Date.now = jest.fn(() => 1524270045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       global.Date.now = jest.fn(() => 1524351045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));
       expect(data).toEqual({
         queries: {
-          brad: [{
-            id: 'brad vogel',
-            timesSelected: 3,
-            selectedAt: [1524085045510, 1524270045510, 1524351045510]
-          }]
+          brad: [
+            {
+              id: 'brad vogel',
+              timesSelected: 3,
+              selectedAt: [1524085045510, 1524270045510, 1524351045510],
+            },
+          ],
         },
         selections: {
           'brad vogel': {
             timesSelected: 3,
             selectedAt: [1524085045510, 1524270045510, 1524351045510],
-            queries: { brad: true }
+            queries: { brad: true },
           },
         },
-        recentSelections: ['brad vogel']
+        recentSelections: ['brad vogel'],
       });
     });
 
@@ -156,181 +167,197 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => 1524085045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       global.Date.now = jest.fn(() => 1524301045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       global.Date.now = jest.fn(() => 1524346045510);
       frecency.save({
         searchQuery: 'vogel',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));
       expect(data).toEqual({
         queries: {
-          brad: [{
-            id: 'brad vogel',
-            timesSelected: 2,
-            selectedAt: [1524085045510, 1524301045510]
-          }],
-          vogel: [{
-            id: 'brad vogel',
-            timesSelected: 1,
-            selectedAt: [1524346045510]
-          }]
+          brad: [
+            {
+              id: 'brad vogel',
+              timesSelected: 2,
+              selectedAt: [1524085045510, 1524301045510],
+            },
+          ],
+          vogel: [
+            {
+              id: 'brad vogel',
+              timesSelected: 1,
+              selectedAt: [1524346045510],
+            },
+          ],
         },
         selections: {
           'brad vogel': {
             timesSelected: 3,
             selectedAt: [1524085045510, 1524301045510, 1524346045510],
-            queries: { brad: true, vogel: true }
-          }
+            queries: { brad: true, vogel: true },
+          },
         },
-        recentSelections: ['brad vogel']
+        recentSelections: ['brad vogel'],
       });
     });
 
     it('limits number of timestamps per query.', () => {
       const frecency = new Frecency({
         key: 'templates',
-        timestampsLimit: 3
+        timestampsLimit: 3,
       });
 
       [1524085000000, 1524086000000, 1524087000000, 1524088000000].forEach((time) => {
         global.Date.now = jest.fn(() => time);
         frecency.save({
           searchQuery: 'brad',
-          selectedId: 'brad vogel'
+          selectedId: 'brad vogel',
         });
       });
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));
       expect(data).toEqual({
         queries: {
-          brad: [{
-            id: 'brad vogel',
-            timesSelected: 4,
-            selectedAt: [1524086000000, 1524087000000, 1524088000000]
-          }]
+          brad: [
+            {
+              id: 'brad vogel',
+              timesSelected: 4,
+              selectedAt: [1524086000000, 1524087000000, 1524088000000],
+            },
+          ],
         },
         selections: {
           'brad vogel': {
             timesSelected: 4,
             selectedAt: [1524086000000, 1524087000000, 1524088000000],
-            queries: { brad: true }
-          }
+            queries: { brad: true },
+          },
         },
-        recentSelections: ['brad vogel']
+        recentSelections: ['brad vogel'],
       });
     });
 
     it('limits number of timestamps per selection.', () => {
       const frecency = new Frecency({
         key: 'templates',
-        timestampsLimit: 3
+        timestampsLimit: 3,
       });
 
       [1524085000000, 1524086000000, 1524087000000, 1524088000000].forEach((time, index) => {
         global.Date.now = jest.fn(() => time);
         frecency.save({
           searchQuery: index % 2 === 0 ? 'brad' : 'vogel',
-          selectedId: 'brad vogel'
+          selectedId: 'brad vogel',
         });
       });
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));
       expect(data).toEqual({
         queries: {
-          brad: [{
-            id: 'brad vogel',
-            timesSelected: 2,
-            selectedAt: [1524085000000, 1524087000000]
-          }],
-          vogel: [{
-            id: 'brad vogel',
-            timesSelected: 2,
-            selectedAt: [1524086000000, 1524088000000]
-          }]
+          brad: [
+            {
+              id: 'brad vogel',
+              timesSelected: 2,
+              selectedAt: [1524085000000, 1524087000000],
+            },
+          ],
+          vogel: [
+            {
+              id: 'brad vogel',
+              timesSelected: 2,
+              selectedAt: [1524086000000, 1524088000000],
+            },
+          ],
         },
         selections: {
           'brad vogel': {
             timesSelected: 4,
             selectedAt: [1524086000000, 1524087000000, 1524088000000],
-            queries: { brad: true, vogel: true }
-          }
+            queries: { brad: true, vogel: true },
+          },
         },
-        recentSelections: ['brad vogel']
+        recentSelections: ['brad vogel'],
       });
     });
 
     it('limits number of IDs saved in frecency.', () => {
       const frecency = new Frecency({
         key: 'templates',
-        recentSelectionsLimit: 2
+        recentSelectionsLimit: 2,
       });
 
       global.Date.now = jest.fn(() => 1524085045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       global.Date.now = jest.fn(() => 1524270045510);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       global.Date.now = jest.fn(() => 1524360045510);
       frecency.save({
         searchQuery: 'simon xi',
-        selectedId: 'simon xiong'
+        selectedId: 'simon xiong',
       });
 
       global.Date.now = jest.fn(() => 1524490045510);
       frecency.save({
         searchQuery: 'simon',
-        selectedId: 'simon xiong'
+        selectedId: 'simon xiong',
       });
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));
       expect(data).toEqual({
         queries: {
-          brad: [{
-            id: 'brad neuberg',
-            timesSelected: 1,
-            selectedAt: [1524270045510]
-          }],
-          'simon xi': [{
-            id: 'simon xiong',
-            timesSelected: 1,
-            selectedAt: [1524360045510]
-          }],
-          simon: [{
-            id: 'simon xiong',
-            timesSelected: 1,
-            selectedAt: [1524490045510]
-          }]
+          brad: [
+            {
+              id: 'brad neuberg',
+              timesSelected: 1,
+              selectedAt: [1524270045510],
+            },
+          ],
+          'simon xi': [
+            {
+              id: 'simon xiong',
+              timesSelected: 1,
+              selectedAt: [1524360045510],
+            },
+          ],
+          simon: [
+            {
+              id: 'simon xiong',
+              timesSelected: 1,
+              selectedAt: [1524490045510],
+            },
+          ],
         },
         selections: {
           'brad neuberg': {
             timesSelected: 1,
             selectedAt: [1524270045510],
-            queries: { brad: true }
+            queries: { brad: true },
           },
           'simon xiong': {
             timesSelected: 2,
             selectedAt: [1524360045510, 1524490045510],
-            queries: { 'simon xi': true, simon: true }
-          }
+            queries: { 'simon xi': true, simon: true },
+          },
         },
-        recentSelections: ['simon xiong', 'brad neuberg']
+        recentSelections: ['simon xiong', 'brad neuberg'],
       });
     });
   });

--- a/spec/sort.test.js
+++ b/spec/sort.test.js
@@ -16,18 +16,26 @@ describe('frecency', () => {
       global.localStorage = undefined;
       const frecency = new Frecency({ key: 'templates' });
 
-      expect(frecency.sort({
-        searchQuery: 'brad',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }]
-      })).toEqual([{
-        _id: 'brad vogel'
-      }, {
-        _id: 'simon xiong'
-      }]);
+      expect(
+        frecency.sort({
+          searchQuery: 'brad',
+          results: [
+            {
+              _id: 'brad vogel',
+            },
+            {
+              _id: 'simon xiong',
+            },
+          ],
+        }),
+      ).toEqual([
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'simon xiong',
+        },
+      ]);
     });
 
     it('should not sort if frecency is empty.', () => {
@@ -35,22 +43,30 @@ describe('frecency', () => {
 
       const results = frecency.sort({
         searchQuery: 'brad',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }, {
-          _id: 'brad neuberg'
-        }]
+        results: [
+          {
+            _id: 'brad vogel',
+          },
+          {
+            _id: 'simon xiong',
+          },
+          {
+            _id: 'brad neuberg',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'brad vogel'
-      }, {
-        _id: 'simon xiong'
-      }, {
-        _id: 'brad neuberg'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'simon xiong',
+        },
+        {
+          _id: 'brad neuberg',
+        },
+      ]);
     });
 
     it('should sort if search query is empty.', () => {
@@ -60,29 +76,37 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => now - 1 * hour);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       global.Date.now = jest.fn(() => now);
 
       const results = frecency.sort({
         searchQuery: '',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }, {
-          _id: 'brad neuberg'
-        }]
+        results: [
+          {
+            _id: 'brad vogel',
+          },
+          {
+            _id: 'simon xiong',
+          },
+          {
+            _id: 'brad neuberg',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'brad neuberg'
-      }, {
-        _id: 'brad vogel'
-      }, {
-        _id: 'simon xiong'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'brad neuberg',
+        },
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'simon xiong',
+        },
+      ]);
     });
 
     it('should sort higher if search query was recently selected.', () => {
@@ -92,29 +116,37 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => now - 1 * hour);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       global.Date.now = jest.fn(() => now);
 
       const results = frecency.sort({
         searchQuery: 'brad',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }, {
-          _id: 'brad neuberg'
-        }]
+        results: [
+          {
+            _id: 'brad vogel',
+          },
+          {
+            _id: 'simon xiong',
+          },
+          {
+            _id: 'brad neuberg',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'brad neuberg'
-      }, {
-        _id: 'brad vogel'
-      }, {
-        _id: 'simon xiong'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'brad neuberg',
+        },
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'simon xiong',
+        },
+      ]);
     });
 
     it('should sort higher if search query is a subquery of recent selected query.', () => {
@@ -124,29 +156,37 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => now - 1 * hour);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       global.Date.now = jest.fn(() => now);
 
       const results = frecency.sort({
         searchQuery: 'br',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }, {
-          _id: 'brad neuberg'
-        }]
+        results: [
+          {
+            _id: 'brad vogel',
+          },
+          {
+            _id: 'simon xiong',
+          },
+          {
+            _id: 'brad neuberg',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'brad neuberg'
-      }, {
-        _id: 'brad vogel'
-      }, {
-        _id: 'simon xiong'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'brad neuberg',
+        },
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'simon xiong',
+        },
+      ]);
     });
 
     it('should sort higher if an ID was recently selected.', () => {
@@ -156,29 +196,37 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => now - 1 * hour);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       global.Date.now = jest.fn(() => now);
 
       const results = frecency.sort({
         searchQuery: 'neuberg',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }, {
-          _id: 'brad neuberg'
-        }]
+        results: [
+          {
+            _id: 'brad vogel',
+          },
+          {
+            _id: 'simon xiong',
+          },
+          {
+            _id: 'brad neuberg',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'brad neuberg'
-      }, {
-        _id: 'brad vogel'
-      }, {
-        _id: 'simon xiong'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'brad neuberg',
+        },
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'simon xiong',
+        },
+      ]);
     });
 
     it('should sort higher if selections are more recent.', () => {
@@ -190,16 +238,16 @@ describe('frecency', () => {
         global.Date.now = jest.fn(() => now - 7 * day);
         frecency.save({
           searchQuery: 'brad',
-          selectedId: 'brad vogel'
+          selectedId: 'brad vogel',
         });
       }
 
       // We select brad neuberg 2 times, but within the last hour.
-      for (let i= 0; i < 2; ++i) {
+      for (let i = 0; i < 2; ++i) {
         global.Date.now = jest.fn(() => now - 1 * hour);
         frecency.save({
           searchQuery: 'brad',
-          selectedId: 'brad neuberg'
+          selectedId: 'brad neuberg',
         });
       }
 
@@ -207,22 +255,30 @@ describe('frecency', () => {
 
       const results = frecency.sort({
         searchQuery: 'brad',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }, {
-          _id: 'brad neuberg'
-        }]
+        results: [
+          {
+            _id: 'brad vogel',
+          },
+          {
+            _id: 'simon xiong',
+          },
+          {
+            _id: 'brad neuberg',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'brad neuberg'
-      }, {
-        _id: 'brad vogel'
-      }, {
-        _id: 'simon xiong'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'brad neuberg',
+        },
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'simon xiong',
+        },
+      ]);
     });
 
     it('should give non-exact matches a reduced score.', () => {
@@ -233,53 +289,63 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => now - 1 * hour);
       frecency.save({
         searchQuery: 'br',
-        selectedId: 'simon xiong'
+        selectedId: 'simon xiong',
       });
 
       // We'll use this as a sub-query match.
       global.Date.now = jest.fn(() => now - 1 * hour);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       // We'll use this as an ID match.
       global.Date.now = jest.fn(() => now - 1 * hour);
       frecency.save({
         searchQuery: 'vogel',
-        selectedId: 'brad vogel'
+        selectedId: 'brad vogel',
       });
 
       global.Date.now = jest.fn(() => now);
 
       const results = frecency.sort({
         searchQuery: 'br',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }, {
-          _id: 'brad neuberg'
-        }, {
-          _id: 'other'
-        }]
+        results: [
+          {
+            _id: 'brad vogel',
+          },
+          {
+            _id: 'simon xiong',
+          },
+          {
+            _id: 'brad neuberg',
+          },
+          {
+            _id: 'other',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'simon xiong'
-      }, {
-        _id: 'brad neuberg'
-      }, {
-        _id: 'brad vogel'
-      }, {
-        _id: 'other'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'simon xiong',
+        },
+        {
+          _id: 'brad neuberg',
+        },
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'other',
+        },
+      ]);
     });
 
     it('supports different ID attribute.', () => {
       const frecency = new Frecency({
         key: 'templates',
-        idAttribute: 'email'
+        idAttribute: 'email',
       });
 
       const now = 1524085045510;
@@ -287,29 +353,35 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => now - 1 * hour);
       frecency.save({
         searchQuery: 'sim',
-        selectedId: 'simon@mixmax.com'
+        selectedId: 'simon@mixmax.com',
       });
 
       global.Date.now = jest.fn(() => now);
 
       const results = frecency.sort({
         searchQuery: 'br',
-        results: [{
-          _id: 'simon@mixmax.com',
-          email: 'other@mixmax.com'
-        }, {
-          _id: 'not simon',
-          email: 'simon@mixmax.com'
-        }]
+        results: [
+          {
+            _id: 'simon@mixmax.com',
+            email: 'other@mixmax.com',
+          },
+          {
+            _id: 'not simon',
+            email: 'simon@mixmax.com',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'not simon',
-        email: 'simon@mixmax.com'
-      }, {
-        _id: 'simon@mixmax.com',
-        email: 'other@mixmax.com'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'not simon',
+          email: 'simon@mixmax.com',
+        },
+        {
+          _id: 'simon@mixmax.com',
+          email: 'other@mixmax.com',
+        },
+      ]);
     });
 
     it('supports unified search using ID attribute function.', () => {
@@ -318,7 +390,7 @@ describe('frecency', () => {
         idAttribute: (result) => {
           // Results are a mix of email contacts or contact groups.
           return result.email || result.groupName;
-        }
+        },
       });
 
       const now = 1524085045510;
@@ -326,43 +398,55 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => now - 1 * day);
       frecency.save({
         searchQuery: 'sim',
-        selectedId: 'simon@mixmax.com'
+        selectedId: 'simon@mixmax.com',
       });
 
       global.Date.now = jest.fn(() => now - 1 * hour);
       frecency.save({
         searchQuery: 'personal',
-        selectedId: 'personal contact group'
+        selectedId: 'personal contact group',
       });
 
       global.Date.now = jest.fn(() => now);
 
       const results = frecency.sort({
         searchQuery: 'per',
-        results: [{
-          email: 'brad@mixmax.com'
-        }, {
-          groupName: 'everyone'
-        }, {
-          email: 'simon@mixmax.com'
-        }, {
-          groupName: 'personal contact group'
-        }, {
-          groupName: 'testing group'
-        }]
+        results: [
+          {
+            email: 'brad@mixmax.com',
+          },
+          {
+            groupName: 'everyone',
+          },
+          {
+            email: 'simon@mixmax.com',
+          },
+          {
+            groupName: 'personal contact group',
+          },
+          {
+            groupName: 'testing group',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        groupName: 'personal contact group'
-      }, {
-        email: 'simon@mixmax.com'
-      }, {
-        email: 'brad@mixmax.com'
-      }, {
-        groupName: 'everyone'
-      }, {
-        groupName: 'testing group'
-      }]);
+      expect(results).toEqual([
+        {
+          groupName: 'personal contact group',
+        },
+        {
+          email: 'simon@mixmax.com',
+        },
+        {
+          email: 'brad@mixmax.com',
+        },
+        {
+          groupName: 'everyone',
+        },
+        {
+          groupName: 'testing group',
+        },
+      ]);
     });
 
     it('fallbacks on subquery matching when query entry is too old (> 14 days)', () => {
@@ -372,37 +456,44 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => now - 15 * day);
       frecency.save({
         searchQuery: 'br',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       global.Date.now = jest.fn(() => now - 2 * day);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       global.Date.now = jest.fn(() => now);
 
       const results = frecency.sort({
         searchQuery: 'br',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }, {
-          _id: 'brad neuberg'
-        }]
+        results: [
+          {
+            _id: 'brad vogel',
+          },
+          {
+            _id: 'simon xiong',
+          },
+          {
+            _id: 'brad neuberg',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'brad neuberg'
-      }, {
-        _id: 'brad vogel'
-      }, {
-        _id: 'simon xiong'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'brad neuberg',
+        },
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'simon xiong',
+        },
+      ]);
     });
-
 
     it('fallbacks on recent selections matching when queries/subqueries are too old (> 14 days)', () => {
       const frecency = new Frecency({ key: 'templates' });
@@ -411,35 +502,43 @@ describe('frecency', () => {
       global.Date.now = jest.fn(() => now - 15 * day);
       frecency.save({
         searchQuery: 'brad',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       global.Date.now = jest.fn(() => now - 2 * day);
       frecency.save({
         searchQuery: 'bra',
-        selectedId: 'brad neuberg'
+        selectedId: 'brad neuberg',
       });
 
       global.Date.now = jest.fn(() => now);
 
       const results = frecency.sort({
         searchQuery: 'brad',
-        results: [{
-          _id: 'brad vogel'
-        }, {
-          _id: 'simon xiong'
-        }, {
-          _id: 'brad neuberg'
-        }]
+        results: [
+          {
+            _id: 'brad vogel',
+          },
+          {
+            _id: 'simon xiong',
+          },
+          {
+            _id: 'brad neuberg',
+          },
+        ],
       });
 
-      expect(results).toEqual([{
-        _id: 'brad neuberg'
-      }, {
-        _id: 'brad vogel'
-      }, {
-        _id: 'simon xiong'
-      }]);
+      expect(results).toEqual([
+        {
+          _id: 'brad neuberg',
+        },
+        {
+          _id: 'brad vogel',
+        },
+        {
+          _id: 'simon xiong',
+        },
+      ]);
     });
   });
 });

--- a/src/types.js
+++ b/src/types.js
@@ -11,8 +11,8 @@ export type FrecencyData = {
 
       // The list of timestamps of the most recent selections, which will
       // be used to calculate relevance scores for each result.
-      selectedAt: number[]
-    }>;
+      selectedAt: number[],
+    }>,
   },
 
   // Stores information about how often a particular result has been chosen
@@ -23,7 +23,6 @@ export type FrecencyData = {
   //    to rank higher because "brad vogel" has been selected very often.
   selections: {
     [id: string]: {
-
       // Total times this result was chosen regardless of the user's search query.
       timesSelected: number,
 
@@ -33,24 +32,25 @@ export type FrecencyData = {
 
       // The set of queries where the user selected this result. Used when removing results
       // from the frecency data in order to limit the size of the frecency object.
-      queries: { [query: string]: true, }
+      queries: { [query: string]: true },
     },
   },
 
   // Cache of recently selected IDs (ordered from most to least recent). When an ID is
   // selected we'll add or shift the ID to the front. When this list exceeds a certain
   // limit, we'll remove the last ID and remove all frecency data for this ID.
-  recentSelections: string[];
+  recentSelections: string[],
 };
 
-export type StorageProvider = any & $ReadOnly<{
-  getItem: (key: string) => ?string,
-  setItem: (key: string, value: string) => void,
-  removeItem: (key: string) => void,
-  key: (n: number) => ?string,
-  clear: () => void,
-  length: number
-}>
+export type StorageProvider = any &
+  $ReadOnly<{
+    getItem: (key: string) => ?string,
+    setItem: (key: string, value: string) => void,
+    removeItem: (key: string) => void,
+    key: (n: number) => ?string,
+    clear: () => void,
+    length: number,
+  }>;
 
 export type FrecencyOptions = {
   key: string,
@@ -69,8 +69,14 @@ export type SaveParams = {
   dateSelection?: Date,
 };
 
+export type ComputeScoreParams = {
+  searchQuery: ?string,
+  item: Object,
+  now?: number,
+};
+
 export type SortParams = {
   searchQuery: ?string,
   results: Object[],
-  keepScores?: boolean
+  keepScores?: boolean,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,8 +17,14 @@ export function isSubQuery(str: ?string, query: string): boolean {
   if (!str) return false;
 
   // Split the string into words and order reverse-alphabetically.
-  const searchStrings = str.toLowerCase().split(' ').sort((a, b) => b > a ? 1 : -1);
-  const queryStrings = query.toLowerCase().split(' ').sort((a, b) => b > a ? 1 : -1);
+  const searchStrings = str
+    .toLowerCase()
+    .split(' ')
+    .sort((a, b) => (b > a ? 1 : -1));
+  const queryStrings = query
+    .toLowerCase()
+    .split(' ')
+    .sort((a, b) => (b > a ? 1 : -1));
 
   // Make sure each search string is a prefix of at least 1 word in the query strings.
   for (const searchString of searchStrings) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,73 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "lib": [
+      "dom",
+      "es2019"
+    ] /* Specify library files to be included in the compilation. */,
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": false /* Skip type checking of declaration files. */,
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+  },
+  "include": ["types/index.d.ts"]
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@
 
 // TypeScript Version: 3.9
 
-declare module "@getstation/frecency" {
+declare module '@getstation/frecency' {
   export type idAttrFn = (result: string) => string;
 
   export type StorageProvider = {
@@ -23,17 +23,14 @@ declare module "@getstation/frecency" {
       subQueryMatchWeight?: number;
       recentSelectionsMatchWeight?: number;
     });
-    save: (arg: {
-      searchQuery: string;
-      selectedId: string;
-      dateSelection?: Date;
-    }) => void;
+    save: (params: { searchQuery: string; selectedId: string; dateSelection?: Date }) => void;
     sort:
-      | ((arg: { searchQuery: string; results: T[] }) => T[])
-      | ((arg: {
+      | ((params: { searchQuery: string; results: T[] }) => T[])
+      | ((params: {
           searchQuery: string;
           results: T[];
           keepScores?: boolean;
         }) => Array<T & { _frecencyScore?: number }>);
+    computeScore: (params: { searchQuery: string; item: T; now?: number }) => number;
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for @getstation/frecency 1.4
+// Project: https://github.com/getstation/frecency
+
+// TypeScript Version: 3.9
+
+declare module "@getstation/frecency" {
+  export type idAttrFn = (result: string) => string;
+
+  export type StorageProvider = {
+    getItem: (key: string) => string | null;
+    setItem: (key: string, value: string) => void;
+    removeItem: (key: string) => void;
+  };
+
+  export default class Frecency<T = any> {
+    constructor(constructOpts: {
+      key: string;
+      idAttribute?: string | idAttrFn;
+      timeStampsLimit?: number;
+      recentSelectionsLimit?: number;
+      storageProvider?: StorageProvider;
+      exactQueryMatchWeight?: number;
+      subQueryMatchWeight?: number;
+      recentSelectionsMatchWeight?: number;
+    });
+    save: (arg: {
+      searchQuery: string;
+      selectedId: string;
+      dateSelection?: Date;
+    }) => void;
+    sort:
+      | ((arg: { searchQuery: string; results: T[] }) => T[])
+      | ((arg: {
+          searchQuery: string;
+          results: T[];
+          keepScores?: boolean;
+        }) => Array<T & { _frecencyScore?: number }>);
+  }
+}


### PR DESCRIPTION
## What is this PR
It resolves ETF-565

## How does it works
- added basic prettier config
- added ts support
- add computeScore public method to be able to compute a score for one item


## Test instructions
- `npm install` (don't use yarn)
- `npm run test:all` should pass

## TODO
- [x] PR linked to the linear task
- [x] Update README
- [x] when this PR is merged, make a new release on npm

