### PR TITLE
[ETF-589] feat: add saveItems method

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ onSearch: (searchQuery) => {
 }
 ```
 
+### Save several items for a same query
+
+If you need to save several items, for example to init the frecency for the first time, it's recommended to use `saveItems` method instead of lopping on all your items and use `save` on each item
+
+```js
+// several selections
+const selections = [
+  { selectedId: '1', dateSelection: new Date(12345) },
+  { selectedId: '2' }, // current Date will be used by default
+];
+
+peopleFrecency.saveItems({
+  searchQuery: '',
+  selections,
+});
+```
+
 ## Configuring Frecency
 
 Frecency will sort on the `_id` attribute by default. You can change this by setting an

--- a/README.md
+++ b/README.md
@@ -85,21 +85,18 @@ onSearch: (searchQuery) => {
 }
 ```
 
-### Save several items for a same query
+### Save multiple items for a same query
 
 If you need to save several items, for example to init the frecency for the first time, it's recommended to use `saveItems` method instead of lopping on all your items and use `save` on each item
 
 ```js
-// several selections
+// in case of multiple selections
 const selections = [
-  { selectedId: '1', dateSelection: new Date(12345) },
-  { selectedId: '2' }, // current Date will be used by default
+  { searchQuery: 'brad', selectedId: '1', dateSelection: new Date(12345) },
+  { searchQuery: '', selectedId: '2' }, // currentDate will be used by default
 ];
 
-peopleFrecency.saveItems({
-  searchQuery: '',
-  selections,
-});
+peopleFrecency.saveItems(selections);
 ```
 
 ## Configuring Frecency

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ onSearch: (searchQuery) => {
 
 ### Save multiple items for a same query
 
-If you need to save several items, for example to init the frecency for the first time, it's recommended to use `saveItems` method instead of lopping on all your items and use `save` on each item
+If you need to save several items - to init the frecency for the first time, for example - it's recommended to use `saveItems` method instead of looping on all your items and use `save` on each of them.
 
 ```js
 // in case of multiple selections

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/frecency",
-  "version": "1.5.1",
+  "version": "1.6.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/frecency",
-  "version": "1.6.0-0",
+  "version": "1.6.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/frecency",
-  "version": "1.6.0-1",
+  "version": "1.6.0-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/frecency",
-  "version": "1.6.0-1",
+  "version": "1.6.0-2",
   "description": "Frecency sorting for search results.",
   "main": "dist/main.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/frecency",
-  "version": "1.6.0-0",
+  "version": "1.6.0-1",
   "description": "Frecency sorting for search results.",
   "main": "dist/main.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/frecency",
-  "version": "1.5.1",
+  "version": "1.6.0-0",
   "description": "Frecency sorting for search results.",
   "main": "dist/main.js",
   "browser": {

--- a/spec/save.test.js
+++ b/spec/save.test.js
@@ -70,19 +70,21 @@ describe('frecency', () => {
       });
     });
 
-    it('stores different selections for the same query.', () => {
+    it('saveItems: stores different selections for the same query.', () => {
       const frecency = new Frecency({ key: 'templates' });
 
-      global.Date.now = jest.fn(() => 1524085045510);
-      frecency.save({
+      frecency.saveItems({
         searchQuery: 'brad',
-        selectedId: 'brad vogel',
-      });
-
-      global.Date.now = jest.fn(() => 1524270045510);
-      frecency.save({
-        searchQuery: 'brad',
-        selectedId: 'brad neuberg',
+        selections: [
+          {
+            selectedId: 'brad vogel',
+            dateSelection: new Date(1524085045510),
+          },
+          {
+            selectedId: 'brad neuberg',
+            dateSelection: new Date(1524270045510),
+          },
+        ],
       });
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));

--- a/spec/save.test.js
+++ b/spec/save.test.js
@@ -21,20 +21,21 @@ describe('frecency', () => {
       ).toBeUndefined();
     });
 
-    it('stores multiple queries.', () => {
+    it('saveItems: stores multiple queries.', () => {
       const frecency = new Frecency({ key: 'templates' });
 
-      global.Date.now = jest.fn(() => 1524085045510);
-      frecency.save({
-        searchQuery: 'brad',
-        selectedId: 'brad vogel',
-      });
-
-      global.Date.now = jest.fn(() => 1524270045510);
-      frecency.save({
-        searchQuery: 'simon xi',
-        selectedId: 'simon xiong',
-      });
+      frecency.saveItems([
+        {
+          searchQuery: 'brad',
+          selectedId: 'brad vogel',
+          dateSelection: new Date(1524085045510),
+        },
+        {
+          searchQuery: 'simon xi',
+          selectedId: 'simon xiong',
+          dateSelection: new Date(1524270045510),
+        },
+      ]);
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));
       expect(data).toEqual({
@@ -73,19 +74,18 @@ describe('frecency', () => {
     it('saveItems: stores different selections for the same query.', () => {
       const frecency = new Frecency({ key: 'templates' });
 
-      frecency.saveItems({
-        searchQuery: 'brad',
-        selections: [
-          {
-            selectedId: 'brad vogel',
-            dateSelection: new Date(1524085045510),
-          },
-          {
-            selectedId: 'brad neuberg',
-            dateSelection: new Date(1524270045510),
-          },
-        ],
-      });
+      frecency.saveItems([
+        {
+          searchQuery: 'brad',
+          selectedId: 'brad vogel',
+          dateSelection: new Date(1524085045510),
+        },
+        {
+          searchQuery: 'brad',
+          selectedId: 'brad neuberg',
+          dateSelection: new Date(1524270045510),
+        },
+      ]);
 
       const data = JSON.parse((localStorage.getItem('frecency_templates'): any));
       expect(data).toEqual({

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ class Frecency {
   save({ searchQuery, selectedId, dateSelection }: SaveParams): void {
     if (!selectedId || !this._localStorageEnabled) return;
 
-    return this.saveItems({ searchQuery, selections: [{ selectedId, dateSelection }] });
+    return this.saveItems([{ searchQuery, selectedId, dateSelection }]);
   }
 
   /**
@@ -74,15 +74,15 @@ class Frecency {
    *   @prop {String} searchQuery - The search query the user entered.
    *   @prop {Date} [dateSelection] - The date on which item has been selected.
    */
-  saveItems({ searchQuery, selections }: SaveItemsParams): void {
-    if (!selections || !selections.length || !this._localStorageEnabled) return;
+  saveItems(items: SaveItemsParams): void {
+    if (!items || !items.length || !this._localStorageEnabled) return;
 
     // Reload frecency here to pick up frecency updates from other tabs.
     const frecency = this._getFrecencyData();
 
     const now = Date.now();
 
-    selections.forEach(({ selectedId, dateSelection }) => {
+    items.forEach(({ selectedId, dateSelection, searchQuery }) => {
       const date = dateSelection ? dateSelection.getTime() : now;
 
       // Associate the selection with the search query used. This lets us sort this

--- a/src/types.js
+++ b/src/types.js
@@ -69,6 +69,11 @@ export type SaveParams = {
   dateSelection?: Date,
 };
 
+export type SaveItemsParams = {
+  selections: { selectedId: string, dateSelection?: Date }[],
+  searchQuery: ?string,
+};
+
 export type ComputeScoreParams = {
   searchQuery: ?string,
   item: Object,

--- a/src/types.js
+++ b/src/types.js
@@ -70,9 +70,10 @@ export type SaveParams = {
 };
 
 export type SaveItemsParams = {
-  selections: { selectedId: string, dateSelection?: Date }[],
+  selectedId: string,
+  dateSelection?: Date,
   searchQuery: ?string,
-};
+}[];
 
 export type ComputeScoreParams = {
   searchQuery: ?string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,7 +12,7 @@ declare module '@getstation/frecency' {
     removeItem: (key: string) => void;
   };
 
-  export type FrecencySelectionPayload = { selectedId: string; dateSelection?: Date };
+  export type FrecencySelectionPayload = { selectedId: string; dateSelection?: Date; searchQuery?: string };
 
   export default class Frecency<T = any> {
     constructor(constructOpts: {
@@ -25,8 +25,8 @@ declare module '@getstation/frecency' {
       subQueryMatchWeight?: number;
       recentSelectionsMatchWeight?: number;
     });
-    save: (params: FrecencySelectionPayload & { searchQuery: string }) => void;
-    saveItems: (params: { searchQuery: string; selections: FrecencySelectionPayload[] }) => void;
+    save: (params: FrecencySelectionPayload) => void;
+    saveItems: (params: FrecencySelectionPayload[]) => void;
     sort:
       | ((params: { searchQuery: string; results: T[] }) => T[])
       | ((params: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,6 +12,8 @@ declare module '@getstation/frecency' {
     removeItem: (key: string) => void;
   };
 
+  export type FrecencySelectionPayload = { selectedId: string; dateSelection?: Date };
+
   export default class Frecency<T = any> {
     constructor(constructOpts: {
       key: string;
@@ -23,7 +25,8 @@ declare module '@getstation/frecency' {
       subQueryMatchWeight?: number;
       recentSelectionsMatchWeight?: number;
     });
-    save: (params: { searchQuery: string; selectedId: string; dateSelection?: Date }) => void;
+    save: (params: FrecencySelectionPayload & { searchQuery: string }) => void;
+    saveItems: (params: { searchQuery: string; selections: FrecencySelectionPayload[] }) => void;
     sort:
       | ((params: { searchQuery: string; results: T[] }) => T[])
       | ((params: {


### PR DESCRIPTION
## What is this PR
Add a way to save several items at a time.
It's useful if you want to import several items in a decent time ;-) 

It's used by ETF-589


A pre-release has been published on `@getstation/frecency@next` channel (npm): https://www.npmjs.com/package/@getstation/frecency/v/1.6.0-2

related wbx PR: https://github.com/getstation/station-web-extension/pull/306

## How does it works
- add a `saveItems` method based on `save` implementation
- refactor `save` to use `saveItems`
- updated flow types
- updated TS types

## Test instructions
- `npm install` (not yarn)
- `npm run test:all` should pass

## TODOs
- [x] update README
- [x] write basic unit tests for `saveItems`
- [ ] when merged, release a v1.6.0
